### PR TITLE
Has reach account

### DIFF
--- a/has_reach_account.sql
+++ b/has_reach_account.sql
@@ -1,0 +1,19 @@
+WITH reach_account_info AS
+  (SELECT DISTINCT cu.id AS user_id,
+                   CASE
+                       WHEN ru.userid IS NULL THEN 0
+                       ELSE 1
+                   END AS has_reach_account,
+                   uf.value AS uf_value
+   FROM ak_moveon.core_user cu
+   JOIN ak_moveon.core_action ca ON ca.user_id = cu.id
+   LEFT JOIN stafftemp.latest_phone lp ON lp.akid = cu.id
+   LEFT JOIN reach.tmc__mvo_users ru ON ru.phonenumber = lp.mobile
+   LEFT JOIN ak_moveon.core_userfield uf ON uf.parent_id = cu.id
+   AND uf.name = 'has_reach_account'
+   WHERE ca.page_id = 33039 )
+SELECT user_id, has_reach_account
+FROM reach_account_info
+WHERE uf_value IS NULL
+  OR uf_value != has_reach_account
+ORDER BY RANDOM()

--- a/sync.py
+++ b/sync.py
@@ -38,7 +38,7 @@ def get_rows(args):
     )
     with open(args.SQL_FILE, 'r') as file:
         query = file.read()
-    query += ' LIMIT %d' % args.SQL_LIMIT
+    query += ' LIMIT %d' % int(args.SQL_LIMIT)
     database_cursor.execute(query)
     return [dict(row) for row in database_cursor.fetchall()]
 


### PR DESCRIPTION
This records if people who signed up for the Mobilize to Win program have Reach accounts yet, so we can follow up with people who signed up but didn't yet join Reach. It also forces the SQL_LIMIT to be an integer, so it can optionally be passed in via command line arg.